### PR TITLE
Allow for override on programe name for help.

### DIFF
--- a/mishmash/__main__.py
+++ b/mishmash/__main__.py
@@ -67,13 +67,13 @@ def main(args):
 
 
 class MishMash(Application):
-    def __init__(self):
+    def __init__(self, progname="mishmash"):
         from . import version
         config_opts = ConfigOpts(required=False,
                                  default_config=DEFAULT_CONFIG(),
                                  default_config_opt="--default-config",
                                  ConfigClass=Config, env_var=CONFIG_ENV_VAR)
-        super().__init__(main, name="mishmash", version=version,
+        super().__init__(main, name=progname, version=version,
                          config_opts=config_opts, pdb_opt=True,
                          gettext_domain="MishMash")
 


### PR DESCRIPTION
Allow a user of mishmash (like say, unsonic) to override the argparser prog for help output.