### PR TITLE
Fix container fail to start issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ ENV MISHMASH_DBURL=${MISHMASH_DBURL} \
 RUN useradd -m -d ${HOME} --uid 6229 mishmash
 
 RUN mkdir -p ${APP_DIR}/bin ${APP_DIR}/etc ${APP_DIR}/var && \
-    chown mishmash:mishmash ${APP_DIR}
+    chown mishmash:mishmash ${APP_DIR} ${APP_DIR}/var
 WORKDIR $APP_DIR
 
 USER mishmash


### PR DESCRIPTION
Update ownership of `${APP_DIR}` and `${APP_DIR}/var`. 

Currently without any mounted paths, the container will fail to start as is, with the following error:

```shell
$ docker run nicfit/mishmash:0.3b5
/MishMash/bin/mishmash-init: line 2: /MishMash/bin/activate: No such file or directory
ERROR:mishmash:[Errno 13] Permission denied: '//MishMash/var/MishMash.db'
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/mishmash/__main__.py", line 49, in main
    retval = args.command_func(args, args.config) or 0
  File "/usr/lib/python3.6/site-packages/mishmash/core.py", line 22, in run
    self.db_conn) = database.init(self.config.db_url)
  File "/usr/lib/python3.6/site-packages/mishmash/database.py", line 41, in init
    create_database(db_url, template="template0")
  File "/usr/lib/python3.6/site-packages/sqlalchemy_utils/functions/database.py", line 565, in create_database
    open(database, 'w').close()
PermissionError: [Errno 13] Permission denied: '//MishMash/var/MishMash.db'
General error:
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/mishmash/__main__.py", line 49, in main
    retval = args.command_func(args, args.config) or 0
  File "/usr/lib/python3.6/site-packages/mishmash/core.py", line 22, in run
    self.db_conn) = database.init(self.config.db_url)
  File "/usr/lib/python3.6/site-packages/mishmash/database.py", line 41, in init
    create_database(db_url, template="template0")
  File "/usr/lib/python3.6/site-packages/sqlalchemy_utils/functions/database.py", line 565, in create_database
    open(database, 'w').close()
PermissionError: [Errno 13] Permission denied: '//MishMash/var/MishMash.db'
```